### PR TITLE
Autodetect revealjs format

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: quartostamp
 Title: RStudio Addin to Insert Quarto Helpers
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: person("Matt", "Dray", , "mwdray@gmail.com", role = c("aut", "cre"))
 Description: An RStudio Addin to insert ('stamp') pre-written classes and divs
     into your Quarto documents.
@@ -13,4 +13,5 @@ RoxygenNote: 7.2.3
 Imports: 
     cli,
     clipr,
-    rstudioapi
+    rstudioapi,
+    yaml

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# quartostamp 0.1.1
+
+* Automatically detect if the active document is 'revealjs' format and set the header level in tabsets one level deeper to level 3 (closes #10, thank you @Lextuga007).
+* Added {yaml} as a dependency to simplify parsing YAML headers.
+
 # quartostamp 0.1.0
 
 * Allowed functions to include the text selected by the user (where appropriate), rather than just inserting a simple skeleton (closes #6, thank you @Lextuga007).
@@ -5,7 +10,6 @@
 * Added messaging for users so they know that the footnote has been added to their clipboard.
 * Updated function documentation to reflect changes.
 * Added {clipr} and {cli}.
-* Bump version to v0.1.0.
 
 # quartostamp 0.0.0.9001
 

--- a/R/stamps.R
+++ b/R/stamps.R
@@ -557,17 +557,28 @@ stamp_scrollable <- function() {
 #'
 #' @export
 stamp_tabset <- function() {
+
+  is_revealjs <- .check_revealjs()
+
+  if (is_revealjs) {
+    heading_level <- 3
+  } else {
+    heading_level <- 2
+  }
+
+  tabset_heading_md <- paste(rep("#", heading_level), collapse = "")
+
   .replace_text(
     pre = paste0(
       "::: {.panel-tabset}\n",
       "\n",
-      "### Tab A\n",
+      paste(tabset_heading_md, "Tab A\n"),
       "\n"
     ),
     body = "Content for Tab A\n",
     post = paste0(
       "\n",
-      "### Tab B\n",
+      paste(tabset_heading_md, "Tab B\n"),
       "\n",
       "Content for Tab B\n",
       "\n",

--- a/R/stamps.R
+++ b/R/stamps.R
@@ -560,10 +560,10 @@ stamp_tabset <- function() {
 
   is_revealjs <- .check_revealjs()
 
+  heading_level <- 2
+
   if (is_revealjs) {
     heading_level <- 3
-  } else {
-    heading_level <- 2
   }
 
   tabset_heading_md <- paste(rep("#", heading_level), collapse = "")

--- a/R/stamps.R
+++ b/R/stamps.R
@@ -529,12 +529,36 @@ stamp_scrollable <- function() {
 
 #' Insert Tabset
 #'
-#' Insert a panel tabset div to a Revealjs presentation slide. Will embed text
-#' selected by the user into the first tab and skeleton help text into the
-#' second, otherwise skeleton help text will be inserted into both tabs.
+#' Insert a panel tabset div. Will embed text selected by the user into the
+#' first tab and skeleton help text into the second, otherwise skeleton help
+#' text will be inserted into both tabs. The header level will depend on the
+#' current document format. Tabs default to header level 2, but will be header
+#' level 3 if the format in the YAML header is specified as 'revealjs'. This is
+#' because a level 2 header demarcates slide boundaries in a reveal.js
+#' presentation written with Quarto.
 #'
 #' @details
-#' The output looks like this if the user hadn't selected any text:
+#' The output looks like this if the user hadn't selected any text and the
+#' document format is not 'revealjs' according to the YAML header:
+#'
+#' ```
+#' ::: {.panel-tabset}
+#'
+#' ## Tab A
+#'
+#' Content for Tab A
+#'
+#' ## Tab B
+#'
+#' Content for Tab B
+#'
+#' :::
+#'
+#' ```
+#'
+#' And if the document has format 'revealjs' in the YAML header:
+#'
+#'
 #' ```
 #' ::: {.panel-tabset}
 #'
@@ -548,7 +572,6 @@ stamp_scrollable <- function() {
 #'
 #' :::
 #'
-#' ```
 #'
 #' @references
 #' [The Quarto documentation website.](https://quarto.org/docs/reference/)

--- a/R/utils.R
+++ b/R/utils.R
@@ -38,3 +38,25 @@
     )
 
 }
+
+.check_revealjs <- function() {
+
+  active_doc <- rstudioapi::getActiveDocumentContext()
+  contents <- active_doc[["contents"]]
+
+  yaml_end_index <- which(contents == "---")[2]
+  yaml_only <- contents[seq(yaml_end_index)]
+
+  yaml_parsed <- yaml::yaml.load(yaml_only)
+
+  has_format <- "format" %in% names(yaml_parsed)
+
+  if (has_format) {
+    is_revealjs <- "revealjs" %in% names(yaml_parsed[["format"]])
+  } else {
+    is_revealjs <- FALSE
+  }
+
+  return(is_revealjs)
+
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -42,6 +42,7 @@
 .check_revealjs <- function() {
 
   active_doc <- rstudioapi::getActiveDocumentContext()
+
   contents <- active_doc[["contents"]]
 
   yaml_end_index <- which(contents == "---")[2]

--- a/R/utils.R
+++ b/R/utils.R
@@ -51,10 +51,23 @@
 
   has_format <- "format" %in% names(yaml_parsed)
 
+  is_revealjs <- FALSE
+
   if (has_format) {
-    is_revealjs <- "revealjs" %in% names(yaml_parsed[["format"]])
-  } else {
-    is_revealjs <- FALSE
+
+    formats <- yaml_parsed[["format"]]
+
+    formats_is_vec <- inherits(formats, "character")
+    formats_is_list <- inherits(formats, "list")
+
+    if (formats_is_vec) {
+      is_revealjs <- "revealjs" %in% formats
+    }
+
+    if (formats_is_list) {
+      is_revealjs <- "revealjs" %in% names(formats)
+    }
+
   }
 
   return(is_revealjs)

--- a/man/stamp_tabset.Rd
+++ b/man/stamp_tabset.Rd
@@ -10,12 +10,33 @@ stamp_tabset()
 Nothing. Text is updated in the active document.
 }
 \description{
-Insert a panel tabset div to a Revealjs presentation slide. Will embed text
-selected by the user into the first tab and skeleton help text into the
-second, otherwise skeleton help text will be inserted into both tabs.
+Insert a panel tabset div. Will embed text selected by the user into the
+first tab and skeleton help text into the second, otherwise skeleton help
+text will be inserted into both tabs. The header level will depend on the
+current document format. Tabs default to header level 2, but will be header
+level 3 if the format in the YAML header is specified as 'revealjs'. This is
+because a level 2 header demarcates slide boundaries in a reveal.js
+presentation written with Quarto.
 }
 \details{
-The output looks like this if the user hadn't selected any text:
+The output looks like this if the user hadn't selected any text and the
+document format is not 'revealjs' according to the YAML header:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{::: \{.panel-tabset\}
+
+## Tab A
+
+Content for Tab A
+
+## Tab B
+
+Content for Tab B
+
+:::
+
+}\if{html}{\out{</div>}}
+
+And if the document has format 'revealjs' in the YAML header:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{::: \{.panel-tabset\}
 


### PR DESCRIPTION
Check if the YAML header contains `revealjs` under `format:`. If so, increase indent of tabset tab-header to level 3 (defaults to level 2).

Closes #10, thank you @Lextuga007.